### PR TITLE
Add Renovate config for npm/pnpm dependencies

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -2,34 +2,34 @@
 # Rules: https://yamllint.readthedocs.io/en/stable/rules.html
 ---
 yaml-files:
-  - '*.yaml'
-  - '*.yml'
-  - '.yamllint'
+    - '*.yaml'
+    - '*.yml'
+    - '.yamllint'
 
 rules:
-  anchors: enable
-  braces: enable
-  brackets: enable
-  colons: enable
-  commas: enable
-  comments:
-    level: warning
-  comments-indentation:
-    level: warning
-  document-end: disable
-  document-start: disable
-  empty-lines: enable
-  empty-values: disable
-  float-values: disable
-  hyphens: enable
-  indentation:
-    spaces: 2
-  key-duplicates: enable
-  key-ordering: disable
-  line-length: disable
-  new-line-at-end-of-file: enable
-  new-lines: enable
-  octal-values: disable
-  quoted-strings: disable
-  trailing-spaces: enable
-  truthy: disable
+    anchors: enable
+    braces: enable
+    brackets: enable
+    colons: enable
+    commas: enable
+    comments:
+        level: warning
+    comments-indentation:
+        level: warning
+    document-end: disable
+    document-start: disable
+    empty-lines: enable
+    empty-values: disable
+    float-values: disable
+    hyphens: enable
+    indentation:
+        spaces: 2
+    key-duplicates: enable
+    key-ordering: disable
+    line-length: disable
+    new-line-at-end-of-file: enable
+    new-lines: enable
+    octal-values: disable
+    quoted-strings: disable
+    trailing-spaces: enable
+    truthy: disable

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,5 @@
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": ["config:recommended"],
+	"enabledManagers": ["npm"]
+}


### PR DESCRIPTION
Adds Renovate config scoped to npm/pnpm (Renovate's npm manager supports pnpm catalogs, which Dependabot can't). Dependabot is left as-is for GitHub Actions. Requires installing the Renovate GitHub App: https://github.com/apps/renovate